### PR TITLE
Remove quotes from record field constructors and accessors

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -72,6 +72,7 @@ library:
     - prettyprinter == 1.1.1
     - protolude == 0.2.1
     - purescript == 0.11.7
+    - text
   source-dirs: lib
 license: BSD3
 maintainer: jones3.hardy@gmail.com


### PR DESCRIPTION
I'm a little worried about what might happen if we have a really long field name but otherwise I think this is better, e.g. it prints

```purescript
type T
  = {foo :: Int, bar :: {baz :: Int, qux :: {lhs :: Int, rhs :: Int}}}
init ::
  T
init = { foo: 1
       , bar: { baz: 2
              , qux: {lhs: 3, rhs: 4}
              }
       }

updated ::
  T
updated = init { foo = 10
               , bar { baz = 20
                     , qux {lhs = 30, rhs = 40}
                     }
               }

expected ::
  T
expected = { foo: 10
           , bar: { baz: 20
                  , qux: {lhs: 30, rhs: 40}
                  }
           }

check l r = l.foo == r.foo && l.bar.baz == r.bar.baz && l.bar.qux.lhs == r.bar.qux.lhs && l.bar.qux.rhs == r.bar.qux.rhs
```
rather than

```purescript
type T
  = {"foo" :: Int, "bar" :: {"baz" :: Int, "qux" :: {"lhs" :: Int, "rhs" :: Int}}}
init ::
  T
init = { "foo": 1
       , "bar": { "baz": 2
                , "qux": {"lhs": 3, "rhs": 4}
                }
       }

updated ::
  T
updated = init { "foo" = 10
               , "bar" { "baz" = 20
                       , "qux" {"lhs" = 30, "rhs" = 40}
                       }
               }

expected ::
  T
expected = { "foo": 10
           , "bar": { "baz": 20
                    , "qux": {"lhs": 30, "rhs": 40}
                    }
           }

check l r = l."foo" == r."foo" && l."bar"."baz" == r."bar"."baz" && l."bar"."qux"."lhs" == r."bar"."qux"."lhs" && l."bar"."qux"."rhs" == r."bar"."qux"."rhs"
```